### PR TITLE
Allow import strategy to update images and variant data

### DIFF
--- a/src/services/product-variant.ts
+++ b/src/services/product-variant.ts
@@ -36,7 +36,8 @@ class ProductVariantService extends MedusaProductVariantService {
       const imageRepo = this.manager_.withRepository(this.imageRepository_);
       variant.images = await imageRepo.upsertImages(update.images);
 
-      return await variantRepo.save(variant);
+      await variantRepo.save(variant);
+      delete update.images;
     }
 
     return super.update(variantOrVariantId, update);

--- a/src/services/product-variant.ts
+++ b/src/services/product-variant.ts
@@ -37,8 +37,9 @@ class ProductVariantService extends MedusaProductVariantService {
       variant.images = await imageRepo.upsertImages(update.images);
 
       await variantRepo.save(variant);
-      delete update.images;
     }
+    
+    delete update.images;
 
     return super.update(variantOrVariantId, update);
   }


### PR DESCRIPTION
I based my import strategy on the default medusa import batch job. While updating products, variants' data was not updated because the update method returned before saving the variant. This also prevented product.updated events from triggering, which probably causes issues with search indexes that need this event to reindex data.

I tracked things down to this service. The changes made it possible for the images and variant data to be updated on import.